### PR TITLE
Made some fixes and some error correction

### DIFF
--- a/app/src/main/java/com/eva/recorderapp/voice_recorder/data/recordings/provider/RecordingSecondaryDataProviderImpl.kt
+++ b/app/src/main/java/com/eva/recorderapp/voice_recorder/data/recordings/provider/RecordingSecondaryDataProviderImpl.kt
@@ -19,7 +19,6 @@ import com.eva.recorderapp.voice_recorder.domain.recordings.provider.VoiceRecord
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
@@ -44,8 +43,7 @@ class RecordingSecondaryDataProviderImpl(
 	override fun getRecordingFromIdAsFlow(recordingId: Long): Flow<ExtraRecordingMetadataModel?> {
 		return recordingsDao.getRecordingMetaDataFromIdAsFlow(recordingId)
 			.flowOn(Dispatchers.IO)
-			.filterNotNull()
-			.map(RecordingsMetaDataEntity::toModel)
+			.map { entity -> entity?.toModel() }
 	}
 
 	override suspend fun insertRecordingMetaData(recordingId: Long): Resource<ExtraRecordingMetadataModel, Exception> {

--- a/app/src/main/java/com/eva/recorderapp/voice_recorder/domain/recordings/provider/TrashRecordingsProvider.kt
+++ b/app/src/main/java/com/eva/recorderapp/voice_recorder/domain/recordings/provider/TrashRecordingsProvider.kt
@@ -25,8 +25,8 @@ interface TrashRecordingsProvider {
 	suspend fun getTrashedVoiceRecordings(): ResourcedTrashRecordingModels
 
 	/**
-	 * Restore the original [RecordedVoiceModel], from the trash for one to one mapping of [TrashRecordingModel]
-	 * on restore they are shown on [VoiceRecordingsProvider.getVoiceRecordingsAsResource]
+	 * Restore the original [RecordedVoiceModel], from the trash for one [TrashRecordingModel]
+	 * if one-to-one mapping exists
 	 * @param recordings a [Collection] of [TrashRecordingModel] to be recovered
 	 * @return [Resource] indicating [recordings] are recovered successfully otherwise [Exception]
 	 */

--- a/app/src/main/java/com/eva/recorderapp/voice_recorder/domain/recordings/provider/VoiceRecordingsProvider.kt
+++ b/app/src/main/java/com/eva/recorderapp/voice_recorder/domain/recordings/provider/VoiceRecordingsProvider.kt
@@ -27,23 +27,11 @@ interface VoiceRecordingsProvider {
 	val voiceRecordingsOnlyThisApp: Flow<ResourcedVoiceRecordingModels>
 
 	/**
-	 * A resourced version of the [voiceRecordingsFlow].[Exception]'s are wrapped so no need
-	 * worry about exceptions
-	 */
-	val voiceRecordingFlowAsResource: Flow<ResourcedVoiceRecordingModels>
-
-	/**
 	 * Gets the current recordings of the current package or all recordings
 	 * determined by [queryAllRecordings]
 	 * @param queryAllRecordings Flag to indicate if external recordings are to be evaluated too
 	 */
 	suspend fun getVoiceRecordings(queryAllRecordings: Boolean = false): VoiceRecordingModels
-
-	/**
-	 * Gets the currently saved recordings from the storage
-	 * @return [Resource.Success] of [VoiceRecordingModels] if everything goes well otherwise [Resource.Error]
-	 */
-	suspend fun getVoiceRecordingsAsResource(): ResourcedVoiceRecordingModels
 
 
 	suspend fun getVoiceRecordingAsResourceFromId(recordingId: Long): Resource<RecordedVoiceModel, Exception>

--- a/app/src/main/java/com/eva/recorderapp/voice_recorder/domain/recordings/provider/VoiceRecordingsProvider.kt
+++ b/app/src/main/java/com/eva/recorderapp/voice_recorder/domain/recordings/provider/VoiceRecordingsProvider.kt
@@ -24,7 +24,7 @@ interface VoiceRecordingsProvider {
 	 * A flow of [ResourcedVoiceRecordingModels] who's [RecordedVoiceModel.owner] is always this app.
 	 * @see RecordedVoiceModel
 	 */
-	val voiceRecordingsOnlyThisApp:Flow<ResourcedVoiceRecordingModels>
+	val voiceRecordingsOnlyThisApp: Flow<ResourcedVoiceRecordingModels>
 
 	/**
 	 * A resourced version of the [voiceRecordingsFlow].[Exception]'s are wrapped so no need
@@ -32,8 +32,12 @@ interface VoiceRecordingsProvider {
 	 */
 	val voiceRecordingFlowAsResource: Flow<ResourcedVoiceRecordingModels>
 
-
-	suspend fun getVoiceRecordings(): VoiceRecordingModels
+	/**
+	 * Gets the current recordings of the current package or all recordings
+	 * determined by [queryAllRecordings]
+	 * @param queryAllRecordings Flag to indicate if external recordings are to be evaluated too
+	 */
+	suspend fun getVoiceRecordings(queryAllRecordings: Boolean = false): VoiceRecordingModels
 
 	/**
 	 * Gets the currently saved recordings from the storage

--- a/app/src/main/java/com/eva/recorderapp/voice_recorder/presentation/navigation/routes/AudioSettingsRoute.kt
+++ b/app/src/main/java/com/eva/recorderapp/voice_recorder/presentation/navigation/routes/AudioSettingsRoute.kt
@@ -39,13 +39,15 @@ fun NavGraphBuilder.audioSettingsRoute(
 			controller.navigate(NavDialogs.ApplicationInfo)
 		},
 		navigation = {
-			IconButton(
-				onClick = dropUnlessResumed(block = controller::popBackStack)
-			) {
-				Icon(
-					imageVector = Icons.AutoMirrored.Default.ArrowBack,
-					contentDescription = stringResource(R.string.back_arrow)
-				)
+			if (controller.previousBackStackEntry?.destination?.route != null) {
+				IconButton(
+					onClick = dropUnlessResumed(block = controller::popBackStack)
+				) {
+					Icon(
+						imageVector = Icons.AutoMirrored.Default.ArrowBack,
+						contentDescription = stringResource(R.string.back_arrow)
+					)
+				}
 			}
 		},
 	)

--- a/app/src/main/java/com/eva/recorderapp/voice_recorder/presentation/navigation/routes/CreateOrUpdateCategoryRoute.kt
+++ b/app/src/main/java/com/eva/recorderapp/voice_recorder/presentation/navigation/routes/CreateOrUpdateCategoryRoute.kt
@@ -36,13 +36,15 @@ fun NavGraphBuilder.createOrUpdateCategoryRoute(
 		state = state,
 		onEvent = viewModel::onEvent,
 		navigation = {
-			IconButton(
-				onClick = dropUnlessResumed(block = controller::popBackStack)
-			) {
-				Icon(
-					imageVector = Icons.AutoMirrored.Default.ArrowBack,
-					contentDescription = stringResource(R.string.back_arrow)
-				)
+			if (controller.previousBackStackEntry?.destination?.route != null) {
+				IconButton(
+					onClick = dropUnlessResumed(block = controller::popBackStack)
+				) {
+					Icon(
+						imageVector = Icons.AutoMirrored.Default.ArrowBack,
+						contentDescription = stringResource(R.string.back_arrow)
+					)
+				}
 			}
 		}
 	)

--- a/app/src/main/java/com/eva/recorderapp/voice_recorder/presentation/navigation/routes/RecordingCategoriesRoute.kt
+++ b/app/src/main/java/com/eva/recorderapp/voice_recorder/presentation/navigation/routes/RecordingCategoriesRoute.kt
@@ -41,13 +41,15 @@ fun NavGraphBuilder.recordingCategories(
 			controller.navigate(NavRoutes.CreateOrUpdateCategory(category.id))
 		},
 		navigation = {
-			IconButton(
-				onClick = dropUnlessResumed(block = controller::popBackStack)
-			) {
-				Icon(
-					imageVector = Icons.AutoMirrored.Default.ArrowBack,
-					contentDescription = stringResource(R.string.back_arrow)
-				)
+			if (controller.previousBackStackEntry?.destination?.route != null) {
+				IconButton(
+					onClick = dropUnlessResumed(block = controller::popBackStack)
+				) {
+					Icon(
+						imageVector = Icons.AutoMirrored.Default.ArrowBack,
+						contentDescription = stringResource(R.string.back_arrow)
+					)
+				}
 			}
 		},
 	)

--- a/app/src/main/java/com/eva/recorderapp/voice_recorder/presentation/navigation/routes/RecordingsRoute.kt
+++ b/app/src/main/java/com/eva/recorderapp/voice_recorder/presentation/navigation/routes/RecordingsRoute.kt
@@ -89,13 +89,15 @@ fun NavGraphBuilder.recordingsRoute(
 			}
 		},
 		navigation = {
-			IconButton(
-				onClick = dropUnlessResumed(block = controller::popBackStack)
-			) {
-				Icon(
-					imageVector = Icons.AutoMirrored.Default.ArrowBack,
-					contentDescription = stringResource(R.string.back_arrow)
-				)
+			if (controller.previousBackStackEntry?.destination?.route != null) {
+				IconButton(
+					onClick = dropUnlessResumed(block = controller::popBackStack)
+				) {
+					Icon(
+						imageVector = Icons.AutoMirrored.Default.ArrowBack,
+						contentDescription = stringResource(R.string.back_arrow)
+					)
+				}
 			}
 		},
 	)

--- a/app/src/main/java/com/eva/recorderapp/voice_recorder/presentation/navigation/routes/SelectRecordingsCategoryRoute.kt
+++ b/app/src/main/java/com/eva/recorderapp/voice_recorder/presentation/navigation/routes/SelectRecordingsCategoryRoute.kt
@@ -42,13 +42,15 @@ fun NavGraphBuilder.selectRecordingCategoryRoute(
 			controller.navigate(NavRoutes.CreateOrUpdateCategory())
 		},
 		navigation = {
-			IconButton(
-				onClick = dropUnlessResumed(block = controller::popBackStack)
-			) {
-				Icon(
-					imageVector = Icons.AutoMirrored.Default.ArrowBack,
-					contentDescription = stringResource(R.string.back_arrow)
-				)
+			if (controller.previousBackStackEntry?.destination?.route != null) {
+				IconButton(
+					onClick = dropUnlessResumed(block = controller::popBackStack)
+				) {
+					Icon(
+						imageVector = Icons.AutoMirrored.Default.ArrowBack,
+						contentDescription = stringResource(R.string.back_arrow)
+					)
+				}
 			}
 		},
 	)

--- a/app/src/main/java/com/eva/recorderapp/voice_recorder/presentation/navigation/routes/TrashRecordingsRoute.kt
+++ b/app/src/main/java/com/eva/recorderapp/voice_recorder/presentation/navigation/routes/TrashRecordingsRoute.kt
@@ -40,13 +40,15 @@ fun NavGraphBuilder.trashRecordingsRoute(
 		recordings = recordings,
 		onScreenEvent = viewModel::onScreenEvent,
 		navigation = {
-			IconButton(
-				onClick = dropUnlessResumed(block = controller::popBackStack)
-			) {
-				Icon(
-					imageVector = Icons.AutoMirrored.Default.ArrowBack,
-					contentDescription = stringResource(R.string.back_arrow)
-				)
+			if (controller.previousBackStackEntry?.destination?.route != null) {
+				IconButton(
+					onClick = dropUnlessResumed(block = controller::popBackStack)
+				) {
+					Icon(
+						imageVector = Icons.AutoMirrored.Default.ArrowBack,
+						contentDescription = stringResource(R.string.back_arrow)
+					)
+				}
 			}
 		},
 	)

--- a/app/src/main/java/com/eva/recorderapp/voice_recorder/presentation/record_player/AudioPlayerViewModel.kt
+++ b/app/src/main/java/com/eva/recorderapp/voice_recorder/presentation/record_player/AudioPlayerViewModel.kt
@@ -125,7 +125,6 @@ class AudioPlayerViewModel @Inject constructor(
 		prepareCurrentRecording()
 		computeWaveforms(audioId)
 		preparePlayer()
-		setShortcutForLastPlayed()
 	}
 
 	fun onControllerEvents(event: ControllerEvents) {
@@ -191,10 +190,7 @@ class AudioPlayerViewModel @Inject constructor(
 	private fun prepareCurrentRecording() = fileProviderUseCase.invoke(audioId)
 		.onEach { res ->
 			when (res) {
-				Resource.Loading -> _currentAudio.value ?: kotlin.run {
-					_isAudioLoaded.update { false }
-				}
-
+				Resource.Loading -> _isAudioLoaded.update { false }
 				is Resource.Error -> {
 					_isAudioLoaded.update { true }
 					val message = res.message ?: res.error.message ?: ""
@@ -204,6 +200,8 @@ class AudioPlayerViewModel @Inject constructor(
 				is Resource.Success -> {
 					_isAudioLoaded.update { true }
 					_currentAudio.update { res.data }
+					// set shortcut only when resource is loaded
+					setShortcutForLastPlayed()
 				}
 			}
 		}.launchIn(viewModelScope)

--- a/app/src/main/java/com/eva/recorderapp/voice_recorder/presentation/recorder/composable/RecorderTopBar.kt
+++ b/app/src/main/java/com/eva/recorderapp/voice_recorder/presentation/recorder/composable/RecorderTopBar.kt
@@ -2,11 +2,19 @@ package com.eva.recorderapp.voice_recorder.presentation.recorder.composable
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.ContentTransform
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.MoreVert
@@ -30,6 +38,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -37,6 +46,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.datasource.CollectionPreviewParameterProvider
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
 import com.eva.recorderapp.R
 import com.eva.recorderapp.ui.theme.RecorderAppTheme
 
@@ -61,7 +72,10 @@ fun RecorderTopBar(
 		actions = {
 			AnimatedContent(
 				targetState = showActions,
-				label = "Is normal action visible"
+				label = "Is normal action visible",
+				transitionSpec = { bookMarksButtonAnimation() },
+				contentAlignment = Alignment.BottomCenter,
+				modifier = Modifier.widthIn(min = 60.dp)
 			) { isNormal ->
 				if (isNormal) {
 					TextButton(onClick = onNavigateToRecordings) {
@@ -110,7 +124,10 @@ fun RecorderTopBar(
 					) {
 						DropdownMenuItem(
 							text = { Text(text = stringResource(id = R.string.menu_option_recycle_bin)) },
-							onClick = onNavigateToBin,
+							onClick = {
+								onNavigateToBin()
+								showDropDown = false
+							},
 							leadingIcon = {
 								Icon(
 									painter = painterResource(id = R.drawable.ic_recycle),
@@ -120,7 +137,10 @@ fun RecorderTopBar(
 						)
 						DropdownMenuItem(
 							text = { Text(text = stringResource(id = R.string.menu_option_settings)) },
-							onClick = onNavigateToSettings,
+							onClick = {
+								onNavigateToSettings()
+								showDropDown = false
+							},
 							leadingIcon = {
 								Icon(
 									painter = painterResource(id = R.drawable.ic_settings),
@@ -135,6 +155,19 @@ fun RecorderTopBar(
 		colors = colors,
 		modifier = modifier,
 	)
+}
+
+private fun bookMarksButtonAnimation(): ContentTransform {
+
+	val slideAnimation = spring<IntOffset>(
+		dampingRatio = Spring.DampingRatioLowBouncy,
+		stiffness = Spring.StiffnessLow
+	)
+
+	val fadeAnimation = tween<Float>(durationMillis = 400, easing = FastOutSlowInEasing)
+
+	return slideInHorizontally(slideAnimation) + scaleIn(fadeAnimation) togetherWith
+			slideOutHorizontally(slideAnimation) + fadeOut(fadeAnimation)
 }
 
 private class BooleanPreviewParams :

--- a/app/src/main/java/com/eva/recorderapp/voice_recorder/presentation/recordings/composable/RecordingCard.kt
+++ b/app/src/main/java/com/eva/recorderapp/voice_recorder/presentation/recordings/composable/RecordingCard.kt
@@ -7,6 +7,8 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
@@ -60,11 +62,12 @@ fun RecordingCard(
 	val context = LocalContext.current
 	val isInspectionMode = LocalInspectionMode.current
 
-	val otherAppText = remember {
-		return@remember if (!isInspectionMode && music.owner != context.packageName  )
-			context.getString(R.string.other_app_subtitle)
-		else null
+	val otherAppText = remember(music.owner, context) {
+		if (isInspectionMode || music.owner == context.packageName) return@remember null
+
+		music.owner ?: context.getString(R.string.other_app_subtitle)
 	}
+
 
 	val clickModifier = if (isSelectable)
 		Modifier.clickable(onClick = onItemSelect, onClickLabel = "Item Selected")
@@ -110,61 +113,63 @@ fun RecordingCard(
 					)
 				else
 					Image(
-						painter = painterResource(id = R.drawable.ic_play_variant),
+						painter = painterResource(id = R.drawable.ic_microphone),
 						contentDescription = null,
 						colorFilter = ColorFilter
 							.tint(color = MaterialTheme.colorScheme.primary),
+						modifier = Modifier.size(24.dp)
 					)
 
 			}
 			Column(
 				modifier = Modifier.weight(1f),
-				verticalArrangement = Arrangement.spacedBy(6.dp)
+				verticalArrangement = Arrangement.spacedBy(4.dp)
 			) {
-				Row(
-					horizontalArrangement = Arrangement.SpaceBetween,
-					verticalAlignment = Alignment.CenterVertically,
-					modifier = Modifier.fillMaxWidth()
+				Text(
+					text = music.displayName,
+					style = MaterialTheme.typography.titleMedium,
+					color = MaterialTheme.colorScheme.primary
+				)
+				Text(
+					text = music.durationAsLocaltime.format(NOTIFICATION_TIMER_TIME_FORMAT),
+					style = MaterialTheme.typography.bodyMedium,
+					color = MaterialTheme.colorScheme.onBackground
+				)
+				AnimatedVisibility(
+					visible = isSelectable && otherAppText != null,
+					enter = slideInVertically(),
+					exit = slideOutVertically()
 				) {
-					Text(
-						text = music.displayName,
-						style = MaterialTheme.typography.titleMedium,
-						color = MaterialTheme.colorScheme.primary
-					)
-					AnimatedVisibility(
-						visible = music.isFavorite,
-						enter = scaleIn() + fadeIn(),
-						exit = scaleOut() + fadeOut()
-					) {
-						Icon(
-							painter = painterResource(R.drawable.ic_star_filled),
-							contentDescription = stringResource(R.string.menu_option_favourite),
-							tint = MaterialTheme.colorScheme.secondary,
-							modifier = Modifier.size(20.dp)
+					otherAppText?.let { text ->
+						Text(
+							text = text,
+							style = MaterialTheme.typography.labelMedium,
+							color = MaterialTheme.colorScheme.tertiary
 						)
 					}
 				}
-				Row(
-					horizontalArrangement = Arrangement.SpaceBetween,
-					verticalAlignment = Alignment.CenterVertically,
-					modifier = Modifier.fillMaxWidth()
+			}
+			Column(
+				horizontalAlignment = Alignment.End,
+				verticalArrangement = Arrangement.spacedBy(6.dp)
+			) {
+				AnimatedVisibility(
+					visible = music.isFavorite,
+					enter = scaleIn() + fadeIn(),
+					exit = scaleOut() + fadeOut()
 				) {
-					Text(
-						text = music.durationAsLocaltime.format(NOTIFICATION_TIMER_TIME_FORMAT),
-						style = MaterialTheme.typography.labelLarge
-					)
-					Text(
-						text = music.recordedAt.format(RECORDING_RECORD_TIME_FORMAT),
-						style = MaterialTheme.typography.bodySmall,
+					Icon(
+						painter = painterResource(R.drawable.ic_star_filled),
+						contentDescription = stringResource(R.string.menu_option_favourite),
+						tint = MaterialTheme.colorScheme.secondary,
+						modifier = Modifier.size(20.dp)
 					)
 				}
-				otherAppText?.let { text ->
-					Text(
-						text = text,
-						style = MaterialTheme.typography.labelSmall,
-						color = MaterialTheme.colorScheme.tertiary
-					)
-				}
+				Text(
+					text = music.recordedAt.format(RECORDING_RECORD_TIME_FORMAT),
+					style = MaterialTheme.typography.bodySmall,
+					color = MaterialTheme.colorScheme.onBackground
+				)
 			}
 		}
 	}


### PR DESCRIPTION
### Ui fixes and correction
- Corrected the storage statistics indicator, the indicator was not provided with `Modifier.fillMaxWidth()` thus the ratio was incorrect, again float conversion was incorrect, and indicator was showing free space as text and graph was opposite, corrected that to show used space.
- `RecordingsCard` fixed the layout , and added an extra supporting text to show if its from other app.
- Corrected animation in `RecorderTopBar` no animation spec was provided.
- Last Recordings shortcut is set when the recording is correctly loaded in the `PlayerScreen`.
- Wrapped all the navigation icon in top bar with if `previousBackStackEntry?.destination?.route != null` to ensure not to show the nav-icon if no previous back stack is not present.

### Data layer correction
- In `RecordingsSecondaryDataProvider` while querying for secondary data added a `filterNotNull` but the flow needs to emit something to run `PlayerFileProviderFromIdUseCase` due to which the player screen was stuck in `Loading` State.
- In `VoiceRecordingProvider` on `getVoiceRecordings` added an param which determines whether to query out all recordings or not. This is put in a `ContentObserver` flow with `flatMap` with settings.

## Conclusion
The bugs aren't fixed completely , but momentarily everything seems working and the `VoiceRecordingProviderImpl` is lot readable now. As this class is responsible for the whole job. If error occurs later it will be fixed then.