### PR TITLE
Refactor: Use of new Media3 API and editor visuals bug fixes

### DIFF
--- a/core/ui/src/main/res/values-bn/strings.xml
+++ b/core/ui/src/main/res/values-bn/strings.xml
@@ -236,4 +236,7 @@
   <string name="action_continue">শুরু করুন</string>
   <string name="onboarding_page_welcome_message">%s এ স্বাগত</string>
   <string name="move_back_to_list">লিস্টে ফিরে যান</string>
+  <string name="action_exit">বাতিল</string>
+  <string name="editor_screen_exiting_warning_dialog_title">এডিট বাতিল করুন</string>
+  <string name="editor_screen_exiting_warning_dialog_desc">এডিটর স্ক্রিন থেকে বেরিয়ে গেলে আপনার সম্পাদনা বাতিল হয়ে যাবে</string>
 </resources>

--- a/core/ui/src/main/res/values-hi/strings.xml
+++ b/core/ui/src/main/res/values-hi/strings.xml
@@ -236,4 +236,7 @@
   <string name="action_continue">जारी रखें</string>
   <string name="onboarding_page_welcome_message">%s में आपका स्वागत है</string>
   <string name="move_back_to_list">लिस्ट पर वापस जाएँ</string>
+  <string name="action_exit">बाहर निकलें</string>
+  <string name="editor_screen_exiting_warning_dialog_title">एडिट रद्द करें</string>
+  <string name="editor_screen_exiting_warning_dialog_desc">एडिटर स्क्रीन से बाहर निकलने पर आपकी चल रही एडिटिंग हट जाएगी</string>
 </resources>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -269,4 +269,7 @@
   <string name="action_continue">Continue</string>
   <string name="onboarding_page_welcome_message">Welcome to %s</string>
   <string name="move_back_to_list">Go back to List</string>
+  <string name="action_exit">Exit</string>
+  <string name="editor_screen_exiting_warning_dialog_title">Cancel Edit</string>
+  <string name="editor_screen_exiting_warning_dialog_desc">Exiting the editor screen will cancel your ongoing editing</string>
 </resources>

--- a/data/editor/src/main/java/com/eva/editor/data/transformer/AudioFileToComposition.kt
+++ b/data/editor/src/main/java/com/eva/editor/data/transformer/AudioFileToComposition.kt
@@ -2,6 +2,7 @@ package com.eva.editor.data.transformer
 
 import android.util.Log
 import androidx.annotation.OptIn
+import androidx.media3.common.C
 import androidx.media3.common.Effect
 import androidx.media3.common.MediaItem
 import androidx.media3.common.audio.AudioProcessor
@@ -62,13 +63,16 @@ internal fun AudioFileModel.toComposition(
 
 	Log.d(TAG, "CLIPPING :${ranges.joinToString("|")}")
 
-	val itemSequence = EditedMediaItemSequence.Builder().also { builder ->
-		editableItems.forEachIndexed { idx, item ->
-			builder.addItem(item)
-			if (gap > Duration.ZERO && idx + 1 < editableItems.size)
-				builder.addGap(gap.inWholeMicroseconds)
+	val itemSequence = EditedMediaItemSequence
+		.Builder(setOf(C.TRACK_TYPE_AUDIO))
+		.also { builder ->
+			editableItems.forEachIndexed { idx, item ->
+				builder.addItem(item)
+				if (gap > Duration.ZERO && idx + 1 < editableItems.size)
+					builder.addGap(gap.inWholeMicroseconds)
+			}
 		}
-	}.build()
+		.build()
 
 	return Composition.Builder(itemSequence)
 		.build()

--- a/data/editor/src/main/java/com/eva/editor/data/transformer/TransformerAwaitResult.kt
+++ b/data/editor/src/main/java/com/eva/editor/data/transformer/TransformerAwaitResult.kt
@@ -83,7 +83,7 @@ internal suspend fun Transformer.awaitResults(
 @UnstableApi
 suspend fun Transformer.awaitResults(mediaItem: MediaItem, outputUri: String): String {
 	val editMediaItem = EditedMediaItem.Builder(mediaItem).build()
-	val sequence = EditedMediaItemSequence.Builder(editMediaItem).build()
+	val sequence = EditedMediaItemSequence.withAudioFrom(listOf(editMediaItem))
 	val composition = Composition.Builder(sequence).build()
 	return awaitResults(composition, outputUri)
 }

--- a/data/editor/src/main/java/com/eva/editor/domain/model/AudioClipConfig.kt
+++ b/data/editor/src/main/java/com/eva/editor/domain/model/AudioClipConfig.kt
@@ -1,12 +1,19 @@
 package com.eva.editor.domain.model
 
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 data class AudioClipConfig(
 	val start: Duration = 0.seconds,
 	val end: Duration = 1.seconds,
 ) {
+
+	constructor(
+		startMillis: Int,
+		endMillis: Int
+	) : this(startMillis.milliseconds, endMillis.milliseconds)
+
 	fun validate(totalDuration: Duration): Boolean {
 		return hasMinimumDuration && start.isPositive() && end <= totalDuration
 	}

--- a/data/player/build.gradle.kts
+++ b/data/player/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
 	implementation(libs.androidx.media3.common)
 	implementation(libs.androidx.media3.exoplayer)
 	implementation(libs.androidx.media3.session)
+	implementation(libs.androidx.media3.inspector)
 
 	// futures to coroutine
 	implementation(libs.androidx.concurrent.futures.ktx)

--- a/data/player/src/main/java/com/eva/player/data/AudioMetadataRetrieverImpl.kt
+++ b/data/player/src/main/java/com/eva/player/data/AudioMetadataRetrieverImpl.kt
@@ -4,8 +4,8 @@ import android.content.Context
 import androidx.concurrent.futures.await
 import androidx.media3.common.MediaItem
 import androidx.media3.common.util.UnstableApi
-import androidx.media3.exoplayer.MetadataRetriever
 import androidx.media3.exoplayer.source.MediaSource
+import androidx.media3.inspector.MetadataRetriever
 import com.eva.player.domain.AudioMetadataRetriever
 import com.eva.recordings.domain.models.AudioFileModel
 import kotlin.time.Duration

--- a/data/player/src/main/java/com/eva/player/data/player/AudioFilePlayerImpl.kt
+++ b/data/player/src/main/java/com/eva/player/data/player/AudioFilePlayerImpl.kt
@@ -1,7 +1,9 @@
 package com.eva.player.data.player
 
 import android.util.Log
+import androidx.annotation.OptIn
 import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
 import com.eva.player.data.util.computeIsPlayerPlaying
 import com.eva.player.data.util.computePlayerTrackData
 import com.eva.player.data.util.toMediaItem
@@ -55,14 +57,14 @@ internal class AudioFilePlayerImpl(private val player: Player) : AudioFilePlayer
 		player.repeatMode = repeatMode
 	}
 
+	@OptIn(UnstableApi::class)
 	override fun onMuteDevice() {
 		val command = player.isCommandAvailable(Player.COMMAND_SET_VOLUME)
 		if (!command) {
 			Log.w(LOGGER, "PLAYER COMMAND NOT FOUND")
 			return
 		}
-		val isStreamMuted = player.volume == 0f
-		player.volume = if (isStreamMuted) 1f else 0f
+		if (player.volume == .0f) player.unmute() else player.mute()
 	}
 
 	override suspend fun preparePlayer(audio: AudioFileModel): Result<Boolean> {

--- a/data/recordings/src/main/java/com/eva/recordings/data/provider/AudioInfoExtractorImpl.kt
+++ b/data/recordings/src/main/java/com/eva/recordings/data/provider/AudioInfoExtractorImpl.kt
@@ -1,0 +1,67 @@
+package com.eva.recordings.data.provider
+
+import android.content.Context
+import android.media.MediaExtractor
+import android.media.MediaFormat
+import android.media.MediaMetadataRetriever
+import android.os.Build
+import androidx.core.net.toUri
+import com.eva.datastore.domain.repository.RecorderAudioSettingsRepo
+import com.eva.location.domain.repository.LocationAddressProvider
+import com.eva.location.domain.utils.parseLocationFromString
+import com.eva.recordings.domain.models.MediaMetaDataInfo
+import com.eva.recordings.domain.provider.AudioInfoExtractor
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.withContext
+
+class AudioInfoExtractorImpl(
+	private val context: Context,
+	private val settings: RecorderAudioSettingsRepo,
+	private val addressProvider: LocationAddressProvider,
+) : AudioInfoExtractor {
+
+	override suspend fun extractMediaData(uri: String): MediaMetaDataInfo? {
+		val extractor = MediaExtractor()
+		val retriever = MediaMetadataRetriever()
+		try {
+			val audioFileUri = uri.toUri()
+			return withContext(Dispatchers.IO) {// set source
+				extractor.setDataSource(context, audioFileUri, null)
+				retriever.setDataSource(context, audioFileUri)
+				// its accountable that there is a single track
+				val mediaFormat = extractor.getTrackFormat(0)
+				val channelCount = mediaFormat.getInteger(MediaFormat.KEY_CHANNEL_COUNT)
+
+				val sampleRate = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+					retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_SAMPLERATE)
+						?.toIntOrNull() ?: 0
+				} else mediaFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE)
+
+				val locationAsString = async {
+					val audioSettings = settings.audioSettings()
+					if (!audioSettings.addLocationInfoInRecording) return@async null
+					val locationString =
+						retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_LOCATION)
+					parseLocationFromString(locationString)
+						?.let { addressProvider.invoke(it).getOrNull() }
+				}
+				val bitRate = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_BITRATE)
+					?.toIntOrNull() ?: mediaFormat.getInteger(MediaFormat.KEY_BIT_RATE)
+
+				MediaMetaDataInfo(
+					channelCount = channelCount,
+					sampleRate = sampleRate,
+					bitRate = bitRate,
+					locationString = locationAsString.await()
+				)
+			}
+		} catch (e: Exception) {
+			e.printStackTrace()
+			return null
+		} finally {
+			retriever.release()
+			extractor.release()
+		}
+	}
+}

--- a/data/recordings/src/main/java/com/eva/recordings/data/provider/PlayerFileProviderImpl.kt
+++ b/data/recordings/src/main/java/com/eva/recordings/data/provider/PlayerFileProviderImpl.kt
@@ -5,31 +5,21 @@ import android.content.ContentUris
 import android.content.Context
 import android.database.ContentObserver
 import android.database.Cursor
-import android.media.MediaExtractor
-import android.media.MediaFormat
-import android.media.MediaMetadataRetriever
-import android.net.Uri
-import android.os.Build
 import android.provider.MediaStore
 import android.util.Log
-import androidx.core.net.toUri
 import androidx.core.os.bundleOf
-import com.eva.datastore.domain.repository.RecorderAudioSettingsRepo
-import com.eva.location.domain.repository.LocationAddressProvider
-import com.eva.location.domain.utils.parseLocationFromString
 import com.eva.recordings.BuildConfig
 import com.eva.recordings.data.utils.evaluateWithTimeRead
 import com.eva.recordings.data.wrapper.RecordingsConstants
 import com.eva.recordings.data.wrapper.RecordingsContentResolverWrapper
 import com.eva.recordings.domain.exceptions.InvalidAudioFileIdException
 import com.eva.recordings.domain.models.AudioFileModel
-import com.eva.recordings.domain.models.MediaMetaDataInfo
+import com.eva.recordings.domain.provider.AudioInfoExtractor
 import com.eva.recordings.domain.provider.PlayerFileProvider
 import com.eva.recordings.domain.provider.ResourcedDetailedRecordingModel
 import com.eva.utils.Resource
 import com.eva.utils.toLocalDateTime
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
@@ -41,9 +31,8 @@ import kotlin.time.Duration.Companion.seconds
 private const val TAG = "PLAYER_FILE_PROVIDER"
 
 internal class PlayerFileProviderImpl(
-	private val context: Context,
-	private val settings: RecorderAudioSettingsRepo,
-	private val addressProvider: LocationAddressProvider,
+	context: Context,
+	private val extractor: AudioInfoExtractor,
 ) : RecordingsContentResolverWrapper(context), PlayerFileProvider {
 
 	private val _projection: Array<String>
@@ -94,7 +83,7 @@ internal class PlayerFileProviderImpl(
 							readTime = BuildConfig.DEBUG
 						) {
 							if (!readMetaData) return@evaluateWithTimeRead null
-							extractMediaInfo(model.fileUri.toUri())
+							extractor.extractMediaData(model.fileUri)
 						}
 						val modelWithMetaData = model.copy(metaData = metaData)
 						// send data with metadata
@@ -159,7 +148,7 @@ internal class PlayerFileProviderImpl(
 						readTime = BuildConfig.DEBUG
 					) {
 						if (!readMetaData) return@use result
-						extractMediaInfo(result.fileUri.toUri())
+						extractor.extractMediaData(result.fileUri)
 					}
 					result.copy(metaData = metaData)
 				} ?: return@withContext Result.failure(InvalidAudioFileIdException())
@@ -167,50 +156,6 @@ internal class PlayerFileProviderImpl(
 		}
 	}
 
-
-	private suspend fun extractMediaInfo(uri: Uri): MediaMetaDataInfo? {
-		val extractor = MediaExtractor()
-		val retriever = MediaMetadataRetriever()
-		try {
-			return withContext(Dispatchers.IO) {// set source
-				extractor.setDataSource(context, uri, null)
-				retriever.setDataSource(context, uri)
-				// its accountable that there is a single track
-				val mediaFormat = extractor.getTrackFormat(0)
-				val channelCount = mediaFormat.getInteger(MediaFormat.KEY_CHANNEL_COUNT)
-
-				val sampleRate = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-					retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_SAMPLERATE)
-						?.toIntOrNull() ?: 0
-				} else mediaFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE)
-
-				val locationAsString = async {
-					val audioSettings = settings.audioSettings()
-					if (!audioSettings.addLocationInfoInRecording) return@async null
-					val locationString =
-						retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_LOCATION)
-					parseLocationFromString(locationString)
-						?.let { addressProvider.invoke(it).getOrNull() }
-				}
-
-				val bitRate = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_BITRATE)
-					?.toIntOrNull() ?: 0
-
-				MediaMetaDataInfo(
-					channelCount = channelCount,
-					sampleRate = sampleRate,
-					bitRate = bitRate,
-					locationString = locationAsString.await()
-				)
-			}
-		} catch (e: Exception) {
-			e.printStackTrace()
-			return null
-		} finally {
-			retriever.release()
-			extractor.release()
-		}
-	}
 
 	private suspend fun evaluateValuesFromCursor(cursor: Cursor): AudioFileModel? {
 		return withContext(Dispatchers.IO) {

--- a/data/recordings/src/main/java/com/eva/recordings/di/RecordingsProviderModule.kt
+++ b/data/recordings/src/main/java/com/eva/recordings/di/RecordingsProviderModule.kt
@@ -8,6 +8,7 @@ import com.eva.datastore.domain.repository.RecorderAudioSettingsRepo
 import com.eva.datastore.domain.repository.RecorderFileSettingsRepo
 import com.eva.location.domain.repository.LocationAddressProvider
 import com.eva.recordings.data.RecordingWidgetInteractorImpl
+import com.eva.recordings.data.provider.AudioInfoExtractorImpl
 import com.eva.recordings.data.provider.PlayerFileProviderImpl
 import com.eva.recordings.data.provider.RecorderFileProviderImpl
 import com.eva.recordings.data.provider.RecordingSecondaryDataProviderImpl
@@ -15,6 +16,7 @@ import com.eva.recordings.data.provider.StorageInfoProviderImpl
 import com.eva.recordings.data.provider.TrashRecordingsProviderApi29Impl
 import com.eva.recordings.data.provider.TrashRecordingsProviderImpl
 import com.eva.recordings.data.provider.VoiceRecordingsProviderImpl
+import com.eva.recordings.domain.provider.AudioInfoExtractor
 import com.eva.recordings.domain.provider.PlayerFileProvider
 import com.eva.recordings.domain.provider.RecorderFileProvider
 import com.eva.recordings.domain.provider.RecordingsSecondaryDataProvider
@@ -32,6 +34,15 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object RecordingsProviderModule {
+
+	@Provides
+	@Singleton
+	fun providesAudioExtractor(
+		@ApplicationContext context: Context,
+		locationProvider: LocationAddressProvider,
+		settings: RecorderAudioSettingsRepo,
+	): AudioInfoExtractor =
+		AudioInfoExtractorImpl(context, settings, locationProvider)
 
 	@Provides
 	@Singleton
@@ -66,9 +77,8 @@ object RecordingsProviderModule {
 	@Singleton
 	fun providesPlayerFileProvider(
 		@ApplicationContext context: Context,
-		locationProvider: LocationAddressProvider,
-		settings: RecorderAudioSettingsRepo,
-	): PlayerFileProvider = PlayerFileProviderImpl(context, settings, locationProvider)
+		extractor: AudioInfoExtractor,
+	): PlayerFileProvider = PlayerFileProviderImpl(context, extractor)
 
 
 	@Provides

--- a/data/recordings/src/main/java/com/eva/recordings/domain/provider/AudioInfoExtractor.kt
+++ b/data/recordings/src/main/java/com/eva/recordings/domain/provider/AudioInfoExtractor.kt
@@ -1,0 +1,8 @@
+package com.eva.recordings.domain.provider
+
+import com.eva.recordings.domain.models.MediaMetaDataInfo
+
+fun interface AudioInfoExtractor {
+
+	suspend fun extractMediaData(uri: String): MediaMetaDataInfo?
+}

--- a/data/visualizer/build.gradle.kts
+++ b/data/visualizer/build.gradle.kts
@@ -8,5 +8,6 @@ android {
 }
 
 dependencies {
+	implementation(libs.androidx.media3.inspector)
 	implementation(project(":data:recordings"))
 }

--- a/data/visualizer/src/main/java/com/com/visualizer/data/AudioVisualizerImpl.kt
+++ b/data/visualizer/src/main/java/com/com/visualizer/data/AudioVisualizerImpl.kt
@@ -2,8 +2,14 @@ package com.com.visualizer.data
 
 import android.content.Context
 import android.util.Log
+import androidx.annotation.OptIn
 import androidx.core.net.toUri
 import androidx.lifecycle.LifecycleOwner
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DefaultDataSource
+import androidx.media3.extractor.DefaultExtractorsFactory
+import androidx.media3.extractor.ExtractorsFactory
 import com.com.visualizer.domain.AudioVisualizer
 import com.com.visualizer.domain.ThreadController
 import com.com.visualizer.domain.VisualizerState
@@ -22,10 +28,18 @@ import kotlinx.coroutines.sync.withLock
 
 private const val TAG = "PLAIN_VISUALIZER"
 
+@OptIn(UnstableApi::class)
 internal class AudioVisualizerImpl(
-	private val context: Context,
+	private val extractor: ExtractorsFactory,
+	private val dataSource: DataSource.Factory,
 	private val threadHandler: ThreadController
 ) : AudioVisualizer {
+
+	constructor(context: Context, threadHandler: ThreadController) : this(
+		extractor = DefaultExtractorsFactory().setConstantBitrateSeekingEnabled(true),
+		dataSource = DefaultDataSource.Factory(context),
+		threadHandler = threadHandler
+	)
 
 	private var _decoder: MediaCodecPCMDataDecoder? = null
 	private val _lock = Mutex()
@@ -81,7 +95,7 @@ internal class AudioVisualizerImpl(
 				// decoder work is done so we can kill it now
 				if (handler != null) threadHandler.stopThread(handler)
 			}
-			decoder.initiateExtraction(context, fileUri.toUri())
+			decoder.initiateExtraction(extractor, dataSource, fileUri.toUri())
 		} catch (e: Exception) {
 			Log.e(TAG, "CANNOT DECODE THIS URI", e)
 			Result.failure(e)

--- a/data/visualizer/src/main/java/com/com/visualizer/data/MediaCodecPCMDataDecoder.kt
+++ b/data/visualizer/src/main/java/com/com/visualizer/data/MediaCodecPCMDataDecoder.kt
@@ -1,16 +1,18 @@
 package com.com.visualizer.data
 
-import android.content.Context
 import android.media.MediaCodec
 import android.media.MediaCodecList
-import android.media.MediaExtractor
 import android.media.MediaFormat
 import android.net.Uri
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
-import com.com.visualizer.domain.exception.ExtractorNoTrackFoundException
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DataSource
+import androidx.media3.extractor.ExtractorsFactory
+import androidx.media3.inspector.MediaExtractorCompat
 import com.com.visualizer.domain.exception.InvalidMimeTypeException
+import com.com.visualizer.domain.exception.MediaExtractorException
 import com.com.visualizer.utils.isThreadAlive
 import com.com.visualizer.utils.safePOST
 import kotlinx.coroutines.CancellationException
@@ -39,6 +41,7 @@ private const val CODEC_TAG = "CODEC_CALLBACK"
 private const val PROCESSING_TAG = "CODEC_PROCESSING"
 private const val EXTRACTOR_TAG = "MEDIA_EXTRACTOR"
 
+@UnstableApi
 @OptIn(ExperimentalAtomicApi::class)
 internal class MediaCodecPCMDataDecoder(
 	private val seekDurationMillis: Int,
@@ -51,7 +54,7 @@ internal class MediaCodecPCMDataDecoder(
 	private var _mediaCodec: MediaCodec? = null
 
 	@Volatile
-	private var _extractor: MediaExtractor? = null
+	private var _extractor: MediaExtractorCompat? = null
 
 	@Volatile
 	private var _codecState = MediaCodecState.RELEASED
@@ -111,7 +114,10 @@ internal class MediaCodecPCMDataDecoder(
 				return
 			}
 			// seek the extractor as we don't need extra data
-			extractor.seekTo(_currentTimeInMs.load() * 1_000L, MediaExtractor.SEEK_TO_CLOSEST_SYNC)
+			extractor.seekTo(
+				_currentTimeInMs.load() * 1_000L,
+				MediaExtractorCompat.SEEK_TO_CLOSEST_SYNC
+			)
 			val sampleSize = extractor.readSampleData(inputBuffer, 0)
 
 			// sample size is zero thus processing done END_OF_STREAM
@@ -191,7 +197,10 @@ internal class MediaCodecPCMDataDecoder(
 	}
 
 	override fun onOutputFormatChanged(codec: MediaCodec, format: MediaFormat) {
-		Log.d(CODEC_TAG, "MEDIA FORMAT CHANGED: $format")
+		if (format.keys.contains(MediaFormat.KEY_DURATION)) {
+			_totalTimeInMs.store(format.duration?.inWholeMilliseconds ?: 0L)
+		}
+		Log.d(CODEC_TAG, "MEDIA FORMAT CHANGED: KEYS:${format.keys}")
 	}
 
 	private fun handleFloatArray(pcm: FloatArray) {
@@ -269,27 +278,38 @@ internal class MediaCodecPCMDataDecoder(
 		_onDecodeComplete = listener
 	}
 
-	suspend fun initiateExtraction(context: Context, fileURI: Uri): Result<Unit> =
-		withContext(ioDispatcher) {
-			_extractor?.release()
-			_extractor = MediaExtractor().apply {
-				setDataSource(context, fileURI, null)
-			}
-			val format = _extractor?.getTrackFormat(0)
-			val mimeType = format?.mimeType
-
-			if (mimeType == null || !mimeType.startsWith("audio"))
-				return@withContext Result.failure(InvalidMimeTypeException())
-
-			if (_extractor?.trackCount == 0)
-				return@withContext Result.failure(ExtractorNoTrackFoundException())
-
-			Log.i(EXTRACTOR_TAG, "EXTRACTOR PREPARED")
-			_extractor?.selectTrack(0)
-			_totalTimeInMs.store(format.duration.inWholeMilliseconds)
-			initiateCodec(format)
-			Result.success(Unit)
+	suspend fun initiateExtraction(
+		extractor: ExtractorsFactory,
+		dataSource: DataSource.Factory,
+		fileURI: Uri
+	): Result<Unit> = withContext(ioDispatcher) {
+		_extractor?.release()
+		_extractor = MediaExtractorCompat(extractor, dataSource).apply {
+			setDataSource(fileURI, 0)
 		}
+		// check track count
+		if (_extractor?.trackCount == 0)
+			return@withContext Result.failure(MediaExtractorException("No track found"))
+
+		val format = _extractor!!.getTrackFormat(0)
+		val mimeType = format.mimeType
+
+		// check audio duration
+		if (!format.keys.contains(MediaFormat.KEY_DURATION))
+			return@withContext Result.failure(MediaExtractorException("Cannot determine track duration"))
+
+		// check mime type
+		if (mimeType == null || !mimeType.startsWith("audio"))
+			return@withContext Result.failure(InvalidMimeTypeException())
+
+		// set the total time
+		_totalTimeInMs.store(format.duration?.inWholeMilliseconds ?: 0L)
+
+		Log.i(EXTRACTOR_TAG, "EXTRACTOR PREPARED")
+		_extractor?.selectTrack(0)
+		initiateCodec(format)
+		Result.success(Unit)
+	}
 
 
 	private fun initiateCodec(format: MediaFormat) {

--- a/data/visualizer/src/main/java/com/com/visualizer/data/MediaFormatExt.kt
+++ b/data/visualizer/src/main/java/com/com/visualizer/data/MediaFormatExt.kt
@@ -24,11 +24,15 @@ internal val MediaFormat.channels: Int
 internal val MediaFormat.sampleRate: Int
 	get() = getInteger(MediaFormat.KEY_SAMPLE_RATE)
 
-internal val MediaFormat.duration: Duration
-	get() = getLong(MediaFormat.KEY_DURATION).microseconds
+internal val MediaFormat.duration: Duration?
+	get() = if (containsKey(MediaFormat.KEY_DURATION))
+		getLong(MediaFormat.KEY_DURATION).microseconds
+	else null
 
 internal val MediaFormat.mimeType: String?
-	get() = getString(MediaFormat.KEY_MIME)
+	get() = if (containsKey(MediaFormat.KEY_MIME))
+		getString(MediaFormat.KEY_MIME)
+	else null
 
 internal val MediaCodec.BufferInfo.isEndOfStream: Boolean
 	get() = flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM != 0

--- a/data/visualizer/src/main/java/com/com/visualizer/domain/exception/ExtractorNoTrackFoundException.kt
+++ b/data/visualizer/src/main/java/com/com/visualizer/domain/exception/ExtractorNoTrackFoundException.kt
@@ -1,3 +1,0 @@
-package com.com.visualizer.domain.exception
-
-class ExtractorNoTrackFoundException : Exception("No tracks found in the associated URI")

--- a/data/visualizer/src/main/java/com/com/visualizer/domain/exception/MediaExtractorException.kt
+++ b/data/visualizer/src/main/java/com/com/visualizer/domain/exception/MediaExtractorException.kt
@@ -1,0 +1,3 @@
+package com.com.visualizer.domain.exception
+
+class MediaExtractorException(override val message: String) : Exception(message)

--- a/feature/editor/src/main/java/com/eva/feature_editor/AudioEditorRoute.kt
+++ b/feature/editor/src/main/java/com/eva/feature_editor/AudioEditorRoute.kt
@@ -86,6 +86,15 @@ fun NavGraphBuilder.audioEditorRoute(controller: NavController) =
 			}
 		}
 
+		LaunchedEffect(lifecycleOwner) {
+			lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+				editorViewModel.clipConfigs.collectLatest {
+					// when clip configs are updated the compressed visuals also get updated
+					visualsViewmodel.updateClipConfigs(it)
+				}
+			}
+		}
+
 		CompositionLocalProvider(LocalSharedTransitionVisibilityScopeProvider provides this) {
 			AudioEditorScreen(
 				loadState = loadState,

--- a/feature/editor/src/main/java/com/eva/feature_editor/AudioEditorRoute.kt
+++ b/feature/editor/src/main/java/com/eva/feature_editor/AudioEditorRoute.kt
@@ -107,6 +107,11 @@ fun NavGraphBuilder.audioEditorRoute(controller: NavController) =
 				isMediaEdited = isMediaEdited,
 				undoRedoState = undoRedoState,
 				transformationState = transformationState,
+				onDismissScreen = {
+					if (controller.previousBackStackEntry != null) {
+						controller.popBackStack()
+					}
+				},
 				navigation = {
 					if (controller.previousBackStackEntry != null) {
 						IconButton(onClick = dropUnlessResumed(block = controller::popBackStack)) {

--- a/feature/editor/src/main/java/com/eva/feature_editor/AudioEditorScreen.kt
+++ b/feature/editor/src/main/java/com/eva/feature_editor/AudioEditorScreen.kt
@@ -1,5 +1,6 @@
 package com.eva.feature_editor
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -24,6 +25,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -31,9 +33,11 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogProperties
 import com.eva.editor.domain.model.AudioClipConfig
 import com.eva.feature_editor.composables.AudioClipChipRow
 import com.eva.feature_editor.composables.EditorActionsAndControls
+import com.eva.feature_editor.composables.EditorBackHandlerDialog
 import com.eva.feature_editor.composables.EditorTopBar
 import com.eva.feature_editor.composables.PlayerTrimSelector
 import com.eva.feature_editor.composables.TransformBottomSheet
@@ -76,9 +80,15 @@ internal fun AudioEditorScreen(
 	undoRedoState: UndoRedoState = UndoRedoState(),
 	transformationState: TransformationState = TransformationState(),
 	navigation: @Composable () -> Unit = {},
+	onDismissScreen: () -> Unit = {},
 ) {
 	val snackBarHostProvider = LocalSnackBarProvider.current
 	val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
+
+	val isBackHandlerEnabled by rememberSaveable(undoRedoState.holdHistory) {
+		mutableStateOf(undoRedoState.holdHistory)
+	}
+	var showDialog by remember { mutableStateOf(false) }
 
 	var showSheet by remember { mutableStateOf(false) }
 	val bottomSheetState = rememberModalBottomSheetState()
@@ -95,6 +105,15 @@ internal fun AudioEditorScreen(
 		onEvent = onEvent,
 		bottomSheetState = bottomSheetState,
 		showSheet = showSheet
+	)
+
+	BackHandler(enabled = isBackHandlerEnabled, onBack = { showDialog = true })
+
+	EditorBackHandlerDialog(
+		showDialog = showDialog,
+		onConfirm = onDismissScreen,
+		onDismiss = { showDialog = false },
+		properties = DialogProperties(dismissOnClickOutside = false)
 	)
 
 	Scaffold(

--- a/feature/editor/src/main/java/com/eva/feature_editor/composables/ExitEditorScreenConfirmDialog.kt
+++ b/feature/editor/src/main/java/com/eva/feature_editor/composables/ExitEditorScreenConfirmDialog.kt
@@ -1,0 +1,72 @@
+package com.eva.feature_editor.composables
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.window.DialogProperties
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.eva.ui.R
+import com.eva.ui.theme.RecorderAppTheme
+
+@Composable
+fun EditorBackHandlerDialog(
+	showDialog: Boolean,
+	onConfirm: () -> Unit,
+	onDismiss: () -> Unit,
+	modifier: Modifier = Modifier,
+	properties: DialogProperties = DialogProperties()
+) {
+	val lifeCycleOwner = LocalLifecycleOwner.current
+	val lifecycleState by lifeCycleOwner.lifecycle.currentStateFlow.collectAsState()
+
+	if (!showDialog) return
+
+	AlertDialog(
+		onDismissRequest = onDismiss,
+		confirmButton = {
+			Button(
+				onClick = onConfirm,
+				enabled = lifecycleState.isAtLeast(Lifecycle.State.RESUMED),
+				colors = ButtonDefaults.buttonColors(
+					containerColor = MaterialTheme.colorScheme.errorContainer,
+					contentColor = MaterialTheme.colorScheme.onErrorContainer
+				)
+			) {
+				Text(
+					text = stringResource(R.string.action_exit),
+					fontWeight = FontWeight.SemiBold
+				)
+			}
+		},
+		dismissButton = {
+			TextButton(
+				onClick = onDismiss,
+				enabled = lifecycleState.isAtLeast(Lifecycle.State.RESUMED),
+				colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.secondary)
+			) {
+				Text(stringResource(R.string.action_cancel))
+			}
+		},
+		title = { Text(text = stringResource(R.string.editor_screen_exiting_warning_dialog_title)) },
+		text = { Text(text = stringResource(R.string.editor_screen_exiting_warning_dialog_desc)) },
+		modifier = modifier,
+		properties = properties,
+	)
+}
+
+@PreviewLightDark
+@Composable
+private fun EditorBackHandlerDialogPreview() = RecorderAppTheme {
+	EditorBackHandlerDialog(showDialog = true, onConfirm = {}, onDismiss = {})
+}

--- a/feature/editor/src/main/java/com/eva/feature_editor/undoredo/UndoRedoState.kt
+++ b/feature/editor/src/main/java/com/eva/feature_editor/undoredo/UndoRedoState.kt
@@ -1,3 +1,10 @@
 package com.eva.feature_editor.undoredo
 
-data class UndoRedoState(val canUndo: Boolean = false, val canRedo: Boolean = false)
+data class UndoRedoState(
+	val canUndo: Boolean = false,
+	val canRedo: Boolean = false
+) {
+
+	val holdHistory: Boolean
+		get() = canUndo || canRedo
+}

--- a/feature/player-shared/build.gradle.kts
+++ b/feature/player-shared/build.gradle.kts
@@ -27,4 +27,6 @@ dependencies {
 	implementation(project(":data:recordings"))
 	implementation(project(":data:interactions"))
 	implementation(project(":data:use_case"))
+
+	testImplementation(libs.mockk)
 }

--- a/feature/player-shared/src/main/java/com/eva/player_shared/PlayerVisualizerViewmodel.kt
+++ b/feature/player-shared/src/main/java/com/eva/player_shared/PlayerVisualizerViewmodel.kt
@@ -111,15 +111,20 @@ class PlayerVisualizerViewmodel @Inject constructor(
 	}
 
 
-	private fun updatesOnConfigChange() {
-		combine(visualizer.normalizedVisualization, _clipConfigs) { visuals, configs ->
+	private fun updatesOnConfigChange() = combine(
+		visualizer.normalizedVisualization,
+		_clipConfigs
+	) { visuals, configs ->
+		try {
 			val newVisuals = visuals.updateArrayViaConfigs(
 				configs = configs,
 				timeInMillisPerBar = RecorderConstants.RECORDER_AMPLITUDES_BUFFER_SIZE
 			)
 			_compressedVisualization.update { newVisuals }
-		}.launchIn(viewModelScope)
-	}
+		} catch (_: IllegalStateException) {
+			_uiEvents.emit(UIEvents.ShowSnackBar("Cannot update visuals"))
+		}
+	}.launchIn(viewModelScope)
 
 	override fun onCleared() {
 		visualizer.cleanUp()

--- a/feature/player-shared/src/main/java/com/eva/player_shared/util/AudioConfigsToVisuals.kt
+++ b/feature/player-shared/src/main/java/com/eva/player_shared/util/AudioConfigsToVisuals.kt
@@ -5,6 +5,7 @@ import com.eva.editor.domain.AudioConfigToActionList
 import com.eva.editor.domain.model.AudioEditAction
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
 import kotlin.math.max
 import kotlin.math.min
 
@@ -12,47 +13,50 @@ private const val TAG = "PLAYER_CONFIG_SETTER"
 
 internal suspend fun FloatArray.updateArrayViaConfigs(
 	configs: AudioConfigToActionList,
-	timeInMillisPerBar: Int = 100
+	timeInMillisPerBar: Int = 100,
+	dispatcher: CoroutineContext = Dispatchers.Default
 ): FloatArray {
-	return withContext(Dispatchers.Default) {
+	require(timeInMillisPerBar > 0) { "timeInMillisPerBar must be positive" }
+	return withContext(dispatcher) {
 		if (configs.isEmpty()) return@withContext this@updateArrayViaConfigs
 		var modifiedArray = copyOf()
-
 		Log.d(TAG, "INITIAL SIZE :${size}")
 
-		// need to apply the config from back to front
-		configs.reversed().forEachIndexed { iteration, (config, action) ->
-			val startSample = (config.start.inWholeMilliseconds / timeInMillisPerBar).toInt()
-			val endSample = (config.end.inWholeMilliseconds / timeInMillisPerBar).toInt()
+		Log.d(TAG, "=========================================================")
+		configs.forEachIndexed { iteration, (config, action) ->
+			val startIndex = (config.start.inWholeMilliseconds / timeInMillisPerBar).toInt()
+			val endIndex = (config.end.inWholeMilliseconds / timeInMillisPerBar).toInt()
 
-			val validStart = max(0, min(startSample, modifiedArray.size))
-			val validEnd = max(0, min(endSample, modifiedArray.size))
+			val validStart = max(0, min(startIndex, modifiedArray.size))
+			val validEnd = max(0, min(endIndex, modifiedArray.size))
 
-			if (validStart <= validEnd) {
+			if (validStart >= validEnd) {
+				val error = "INVALID RANGE: [$validStart:$validEnd] ACT:$action I_TER:$iteration"
+				Log.e(TAG, error)
+				throw IllegalStateException(error)
+			}
 
-				val message = when (action) {
-					AudioEditAction.CROP -> "NEW START :${validStart} NEW END:$validEnd"
-					AudioEditAction.CUT -> "START1 :0 END1:$validStart || START2 :$validEnd END2: ${modifiedArray.size}"
+			Log.d(TAG, "ITERATION:$iteration")
+
+			when (action) {
+				AudioEditAction.CUT -> {
+					Log.d(TAG, "ACTION:CUT [START :${validStart} END:$validEnd]")
+					val before = modifiedArray.copyOfRange(0, validStart)
+					val after = modifiedArray.copyOfRange(validEnd, modifiedArray.size)
+					modifiedArray = before + after
 				}
 
-				Log.i(TAG, "ITERATION:$iteration $message")
-
-				modifiedArray = when (action) {
-					AudioEditAction.CUT -> {
-						val before = modifiedArray.copyOfRange(0, validStart)
-						val after = modifiedArray.copyOfRange(validEnd, modifiedArray.size)
-						before + after
-					}
-
-					AudioEditAction.CROP ->
-						modifiedArray.copyOfRange(validStart, validEnd)
+				AudioEditAction.CROP -> {
+					Log.d(
+						TAG,
+						"ACTION:CROP [START :0 END:$validStart] ---xx--  [START:$validEnd END: ${modifiedArray.size}]"
+					)
+					modifiedArray = modifiedArray.copyOfRange(validStart, validEnd)
 				}
-			} else {
-				val error = "Invalid clip: $validStart, $validEnd. $action at index $iteration"
-				Log.w(TAG, error)
 			}
 		}
-		Log.d(TAG, "Final array size after processing: ${modifiedArray.size}")
+		Log.d(TAG, "=========================================================")
+		Log.d(TAG, "FINAL ARRAY SIZE AFTER PROCESSING: ${modifiedArray.size}")
 		modifiedArray
 	}
 }

--- a/feature/player-shared/src/test/java/com/eva/player_shared/util/UpdateArrayViaConfigsTest.kt
+++ b/feature/player-shared/src/test/java/com/eva/player_shared/util/UpdateArrayViaConfigsTest.kt
@@ -1,0 +1,133 @@
+package com.eva.player_shared.util
+
+import android.util.Log
+import com.eva.editor.domain.model.AudioClipConfig
+import com.eva.editor.domain.model.AudioEditAction
+import io.mockk.every
+import io.mockk.mockkStatic
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertArrayEquals
+import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.assertEquals
+
+class UpdateArrayViaConfigsTest {
+
+	private val timePerBlock = 100
+
+	@BeforeTest
+	fun setup() {
+		mockkStatic(Log::class)
+		every { Log.d(any(), any()) } returns 0
+		every { Log.i(any(), any()) } returns 0
+		every { Log.e(any(), any()) } returns 0
+	}
+
+	@Test
+	fun `cut removes the middle section`() = runTest {
+		val original = FloatArray(10)
+		val configs = listOf(
+			AudioClipConfig(2 * timePerBlock, 5 * timePerBlock) to AudioEditAction.CUT
+		)
+		val result = original.updateArrayViaConfigs(configs, timePerBlock)
+		val expectedSize = FloatArray(7)
+		assertArrayEquals(expectedSize, result, 0.0f)
+	}
+
+	@Test
+	fun `crop removes the boundary`() = runTest {
+		val original = FloatArray(10)
+		val configs = listOf(
+			AudioClipConfig(2 * timePerBlock, 5 * timePerBlock) to AudioEditAction.CROP
+		)
+		val result = original.updateArrayViaConfigs(configs, timePerBlock)
+		val expected = FloatArray(3)
+		assertArrayEquals(expected, result, 0.0f)
+	}
+
+	@Test(expected = IllegalStateException::class)
+	fun `range is reveres should throw an exception`() = runTest {
+		val original = FloatArray(3)
+		val configs = listOf(
+			AudioClipConfig(5 * timePerBlock, 2 * timePerBlock) to AudioEditAction.CUT
+		)
+		original.updateArrayViaConfigs(configs, timePerBlock)
+	}
+
+	@Test
+	fun `empty configs don't change the array content`() = runTest {
+		val original = FloatArray(10)
+		val configs = emptyList<Pair<AudioClipConfig, AudioEditAction>>()
+
+		val result = original.updateArrayViaConfigs(configs, timePerBlock)
+		assertArrayEquals(original, result, 0.0f)
+	}
+
+	@Test
+	fun `cut then cut then crop`() = runTest {
+		val original = FloatArray(10)
+		val configs = listOf(
+			AudioClipConfig(timePerBlock, 3 * timePerBlock) to AudioEditAction.CUT,
+			AudioClipConfig(5 * timePerBlock, 7 * timePerBlock) to AudioEditAction.CUT,
+			AudioClipConfig(timePerBlock, 4 * timePerBlock) to AudioEditAction.CROP
+		)
+		val result = original.updateArrayViaConfigs(configs, timePerBlock)
+
+		val expected = FloatArray(3)
+		assertArrayEquals(expected, result, 0.0f)
+	}
+
+	@Test
+	fun `cut from front and cut from back`() = runTest {
+		val original = FloatArray(10) { it.toFloat() }
+
+		val configs = listOf(
+			AudioClipConfig(7 * timePerBlock, 10 * timePerBlock) to AudioEditAction.CUT,
+			AudioClipConfig(0, 3 * timePerBlock) to AudioEditAction.CUT
+		)
+		val result = original.updateArrayViaConfigs(configs, timePerBlock)
+		val expected = floatArrayOf(3f, 4f, 5f, 6f)
+		assertArrayEquals(expected, result, 0.0f)
+	}
+
+	@Test
+	fun `cropping the array two times`() = runTest {
+		val original = FloatArray(10) { (it * 10).toFloat() }
+
+		val configs = listOf(
+			AudioClipConfig(2 * timePerBlock, 8 * timePerBlock) to AudioEditAction.CROP,
+			AudioClipConfig(timePerBlock, 4 * timePerBlock) to AudioEditAction.CROP
+		)
+
+		val result = original.updateArrayViaConfigs(configs, timePerBlock)
+
+		val expected = floatArrayOf(30f, 40f, 50f)
+		assertArrayEquals(expected, result, 0.0f)
+	}
+
+	@Test
+	fun `combine a mix of cut and crop 1`() = runTest {
+		val original = floatArrayOf(1f, 2f, 3f, 4f, 5f)
+
+		val configs = listOf(
+			AudioClipConfig(0, 3 * timePerBlock) to AudioEditAction.CUT,
+			AudioClipConfig(0, timePerBlock) to AudioEditAction.CROP,
+			AudioClipConfig(0, timePerBlock) to AudioEditAction.CUT
+		)
+		val result = original.updateArrayViaConfigs(configs, timePerBlock)
+		assertEquals(0, result.size)
+	}
+
+	@Test
+	fun `combine a mix of cut and crop 2`() = runTest {
+		val original = FloatArray(10) { it.toFloat() }
+
+		val configs = listOf(
+			AudioClipConfig(3 * timePerBlock, 7 * timePerBlock) to AudioEditAction.CUT,
+			AudioClipConfig(2 * timePerBlock, 4 * timePerBlock) to AudioEditAction.CROP,
+		)
+		val result = original.updateArrayViaConfigs(configs, timePerBlock)
+		val expected = floatArrayOf(2f, 7f)
+		assertArrayEquals(expected, result, 0f)
+	}
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.13.1"
+agp = "8.13.2"
 concurrentFuturesKtx = "1.3.0"
 datastore = "1.2.0"
 coreSplashscreen = "1.2.0"
@@ -17,23 +17,23 @@ kotlinxCollectionsImmutable = "0.4.0"
 kotlinxDatetime = "0.7.1"
 kotlinxSerializationJson = "1.9.0"
 lifecycleRuntimeKtx = "2.10.0"
-activityCompose = "1.12.1"
-composeBom = "2025.12.00"
-ksp = "2.3.0"
+activityCompose = "1.12.2"
+composeBom = "2025.12.01"
+ksp = "2.3.4"
 hilt = "2.57.2"
-media3Common = "1.8.0"
+media3Common = "1.9.0"
 navigationCompose = "2.9.6"
 playServicesLocationVersion = "21.3.0"
 roomCompiler = "2.8.4"
 uiTextGoogleFonts = "1.10.0"
 workRuntimeKtxVersion = "2.11.0"
 hiltWork = "1.3.0"
-protobufJavalite = "4.33.1"
+protobufJavalite = "4.33.2"
 protobuf_version = "0.9.5"
 protobuf_gen_java_lite = "3.0.0"
 materialIconExtended = "1.7.8"
 moduleGrapher = "0.13.0"
-mockk = "1.14.6"
+mockk = "1.14.7"
 coroutines = "1.10.2"
 turbine_version = "1.2.1"
 compileSdk = "36"
@@ -64,6 +64,7 @@ androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", versi
 androidx-media3-session = { module = "androidx.media3:media3-session", version.ref = "media3Common" }
 androidx-media3-transformer = { module = "androidx.media3:media3-transformer", version.ref = "media3Common" }
 androidx-media3-effects = { module = "androidx.media3:media3-effect", version.ref = "media3Common" }
+androidx-media3-inspector = { module = "androidx.media3:media3-inspector", version.ref = "media3Common" }
 androidx-media3-extractor = { module = "androidx.media3:media3-extractor", version.ref = "media3Common" }
 androidx-media3-decoder = { module = "androidx.media3:media3-decoder", version.ref = "media3Common" }
 androidx-media3-ui = { module = "androidx.media3:media3-ui-compose-material3", version.ref = "media3Common" }

--- a/stability_config.conf
+++ b/stability_config.conf
@@ -7,6 +7,7 @@ com.eva.bookmarks.domain.AudioBookmarkModel
 com.eva.categories.domain.models.*
 com.eva.datastore.domain.models.*
 com.eva.datastore.domain.enums.*
+com.eva.editor.domain.model.*
 com.eva.interactions.domain.enums.*
 com.eva.location.domain.BaseLocationModel
 com.eva.player.domain.model.*


### PR DESCRIPTION
## Changes
- Using the new `MediaExtractorCompact` api from `media-inspector` for audio clip decoding. Updated `MediaCodecPCMDataDecoder.kt` support this new API.
- `AudioInfoExtractor.kt` now handles media info extraction logic, allowing `PlayerFileProviderImpl.kt` to focus strictly on file metadata
- Audio Controls: Switched to native player Mute/Unmute APIs in `AudioFilePlayerImpl.kt`.

## Bug fixes
- Editor edits weren't not being propagated to the visualization corrected that
- Updated `AudioConfigsToVisuals.kt` and `PlayerVisualizerViewmodel.kt` to ensure visuals are not updated while in an invalid state.

## Others
- Included an Exit Confirmation Dialog in the Editor screen to prevent accidental data loss during clip editing.
- Added `UpdateArrayViaConfigsTest.kt` to verify visual data processing and a secondary AudioClipConfig.kt for test isolation.
- Updated `libs.versions.toml` , cleaned up .idea files, and added editor module domain-level classes to stability_config.conf.